### PR TITLE
Allow program to run as a traditional CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@ The program in Java that compares any 2 images and shows the differences visuall
 * The output of the comparison is a copy of one of the images The differences are outlined with red rectangles as shown below.
 * No third party libraries or borrowed code are in usage.
 
-## Getting Started
-To run project open `Terminal` and write: 
+## Building
+
+To clone and build this project, run the following commands:
+ 
 ```
 $ git clone https://github.com/romankh3/image-comparison
 $ cd image-comparison
-$ ./run.sh
+$ ./gradlew check jar
 ```
 
+This will compile, run the tests, and create a runnable jar at `${projectDir}/build/libs`.
+
+## Running the demo
+
+Run the `./run.sh` script to run the demo.
 
 You will get the result of comparing two images.
 The images, which are using:
@@ -44,6 +51,46 @@ ${projectDir}/src/main/resources/image2.png
 ```
 ```
 ${projectDir}/build/result.png
+```
+
+## Using the command-line
+
+This library can be used as a command-line utility to compare two images.
+
+After building with `./gradlew jar`, you will find the runnable jar at `${projectDir}/build/libs`.
+
+To compare two images in files `a.png` and `b.png`, for example, run:
+
+```
+java -jar image-comparison.jar a.png b.png
+```
+
+To save the result image in a third file, say `comparison.png`, just give that file as a third argument:
+
+```
+java -jar image-comparison.jar a.png b.png comparison.png
+```
+
+To show more usage details, run:
+
+```
+java -jar image-comparison.jar -h
+```
+
+## Using as a Java library
+
+To compare two images programmatically, basic usage is as follows:
+
+```java
+class Example {
+    public static void main( String[] args ) {
+        // load the images to be compared
+        BufferedImage image1 = ImageIO.read( new File( "image1.png" )  );
+        BufferedImage image2 = ImageIO.read( new File( "image2.png" )  );
+        // compare them
+        BufferedImage drawnDifferences = new ImageComparison( image1, image2 ).compareImages();
+    }
+}
 ```
 
 ## License:

--- a/README.md
+++ b/README.md
@@ -87,8 +87,12 @@ class Example {
         // load the images to be compared
         BufferedImage image1 = ImageIO.read( new File( "image1.png" )  );
         BufferedImage image2 = ImageIO.read( new File( "image2.png" )  );
+        
+        // where to save the result (leave null if you want to see the result in the UI)
+        File result = new File( "result.png" );
+        
         // compare them
-        BufferedImage drawnDifferences = new ImageComparison( image1, image2 ).compareImages();
+        BufferedImage drawnDifferences = new ImageComparison( image1, image2, result ).compareImages();
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ group 'image-comparison'
 version '1.0-SNAPSHOT'
 sourceCompatibility = 1.8
 
+mainClassName = "ua.comparison.image.ImageComparison"
+
 repositories {
     mavenCentral()
 }
@@ -17,6 +19,11 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
+jar {
+    manifest {
+        attributes 'Main-Class': mainClassName
+    }
+}
 
 jacocoTestReport {
     reports {
@@ -27,5 +34,3 @@ jacocoTestReport {
 
 defaultTasks << 'clean'
 defaultTasks << 'build'
-
-mainClassName = "ua.comparison.image.ImageComparison"

--- a/src/main/java/ua/comparison/image/ArgsParser.java
+++ b/src/main/java/ua/comparison/image/ArgsParser.java
@@ -5,7 +5,19 @@ import java.util.Optional;
 
 final class ArgsParser {
 
-    public Optional<Arguments> parseArgs(String... args) {
+    private final Runnable successExit;
+    private final Runnable errorExit;
+
+    ArgsParser() {
+        this(() -> System.exit(0), () -> System.exit(1));
+    }
+
+    ArgsParser(Runnable successExit, Runnable errorExit) {
+        this.successExit = successExit;
+        this.errorExit = errorExit;
+    }
+
+    Optional<Arguments> parseArgs(String... args) {
         if (args.length == 0) {
             return Optional.empty();
         }
@@ -18,28 +30,17 @@ final class ArgsParser {
         } else if (args.length == 2 || args.length == 3) {
             File image1 = new File(args[0]);
             File image2 = new File(args[1]);
-            String errorMessage = "";
-            if (!image1.isFile()) {
-                errorMessage += image1 + " is not a file!";
+            File result = null;
+            if (args.length == 3) {
+                result = new File(args[2]);
             }
-            if (!image2.isFile()) {
-                errorMessage += (errorMessage.isEmpty() ? "" : "\n") + image2 + " is not a file!";
-            }
-            if (errorMessage.isEmpty()) {
-                File result = null;
-                if (args.length == 3) {
-                    result = new File(args[2]);
-                }
-                return Optional.of(new Arguments(image1, image2, result));
-            } else {
-                return error(errorMessage);
-            }
+            return Optional.of(new Arguments(image1, image2, result));
         } else {
             return error("Too many arguments. To see usage, use the '-h' option");
         }
     }
 
-    private static Optional<Arguments> help() {
+    private Optional<Arguments> help() {
         System.out.println("Java ImageComparison Tool\n" +
                 "\n" +
                 "Usage:\n" +
@@ -52,13 +53,13 @@ final class ArgsParser {
                 "Options:\n" +
                 "    -h --help  print this help message\n\n" +
                 "If no arguments are provided, two demo images are compared and the difference displayed in the UI.\n");
-        System.exit(0);
+        successExit.run();
         return Optional.empty();
     }
 
-    private static Optional<Arguments> error(String errorMessage) {
+    private Optional<Arguments> error(String errorMessage) {
         System.err.println(errorMessage);
-        System.exit(1);
+        errorExit.run();
         return Optional.empty();
     }
 
@@ -67,21 +68,21 @@ final class ArgsParser {
         private final File image2;
         private final File destinationImage;
 
-        public Arguments(File image1, File image2, File destinationImage) {
+        Arguments(File image1, File image2, File destinationImage) {
             this.image1 = image1;
             this.image2 = image2;
             this.destinationImage = destinationImage;
         }
 
-        public File getImage1() {
+        File getImage1() {
             return image1;
         }
 
-        public File getImage2() {
+        File getImage2() {
             return image2;
         }
 
-        public Optional<File> getDestinationImage() {
+        Optional<File> getDestinationImage() {
             return Optional.ofNullable(destinationImage);
         }
     }

--- a/src/main/java/ua/comparison/image/ArgsParser.java
+++ b/src/main/java/ua/comparison/image/ArgsParser.java
@@ -1,0 +1,89 @@
+package ua.comparison.image;
+
+import java.io.File;
+import java.util.Optional;
+
+final class ArgsParser {
+
+    public Optional<Arguments> parseArgs(String... args) {
+        if (args.length == 0) {
+            return Optional.empty();
+        }
+        if (args.length == 1) {
+            if (args[0].equals("-h") || args[0].equals("--help")) {
+                return help();
+            } else {
+                return error("Unrecognized option: '" + args[0] + "'. To see usage, use the '-h' option");
+            }
+        } else if (args.length == 2 || args.length == 3) {
+            File image1 = new File(args[0]);
+            File image2 = new File(args[1]);
+            String errorMessage = "";
+            if (!image1.isFile()) {
+                errorMessage += image1 + " is not a file!";
+            }
+            if (!image2.isFile()) {
+                errorMessage += (errorMessage.isEmpty() ? "" : "\n") + image2 + " is not a file!";
+            }
+            if (errorMessage.isEmpty()) {
+                File result = null;
+                if (args.length == 3) {
+                    result = new File(args[2]);
+                }
+                return Optional.of(new Arguments(image1, image2, result));
+            } else {
+                return error(errorMessage);
+            }
+        } else {
+            return error("Too many arguments. To see usage, use the '-h' option");
+        }
+    }
+
+    private static Optional<Arguments> help() {
+        System.out.println("Java ImageComparison Tool\n" +
+                "\n" +
+                "Usage:\n" +
+                "  java -jar image-comparison.jar <options> [image1 image2 [result]]\n" +
+                "where:\n" +
+                "    image1     the first image to compare.\n" +
+                "    image2     the second image to compare.\n" +
+                "    result     the comparison result image. If not provided, the image is shown in a UI.\n" +
+                "\n" +
+                "Options:\n" +
+                "    -h --help  print this help message\n\n" +
+                "If no arguments are provided, two demo images are compared and the difference displayed in the UI.\n");
+        System.exit(0);
+        return Optional.empty();
+    }
+
+    private static Optional<Arguments> error(String errorMessage) {
+        System.err.println(errorMessage);
+        System.exit(1);
+        return Optional.empty();
+    }
+
+    static final class Arguments {
+        private final File image1;
+        private final File image2;
+        private final File destinationImage;
+
+        public Arguments(File image1, File image2, File destinationImage) {
+            this.image1 = image1;
+            this.image2 = image2;
+            this.destinationImage = destinationImage;
+        }
+
+        public File getImage1() {
+            return image1;
+        }
+
+        public File getImage2() {
+            return image2;
+        }
+
+        public Optional<File> getDestinationImage() {
+            return Optional.ofNullable(destinationImage);
+        }
+    }
+
+}

--- a/src/main/java/ua/comparison/image/IOConsumer.java
+++ b/src/main/java/ua/comparison/image/IOConsumer.java
@@ -1,0 +1,8 @@
+package ua.comparison.image;
+
+import java.io.IOException;
+
+@FunctionalInterface
+interface IOConsumer<T> {
+    void accept(T t) throws IOException;
+}

--- a/src/main/java/ua/comparison/image/ImageComparison.java
+++ b/src/main/java/ua/comparison/image/ImageComparison.java
@@ -35,6 +35,10 @@ public class ImageComparison {
     private final BufferedImage image2;
     private int[][] matrix;
 
+    ImageComparison( String image1, String image2 ) throws IOException, URISyntaxException {
+        this( readImageFromResources(image1), readImageFromResources(image2) );
+    }
+
     ImageComparison( BufferedImage image1, BufferedImage image2 ) {
         this.image1 = image1;
         this.image2 = image2;

--- a/src/main/java/ua/comparison/image/ImageComparison.java
+++ b/src/main/java/ua/comparison/image/ImageComparison.java
@@ -65,16 +65,15 @@ public class ImageComparison {
         return Optional.ofNullable( destination );
     }
 
-    public static void main(String[] args ) throws IOException, URISyntaxException {
-        Optional<ArgsParser.Arguments> arguments = new ArgsParser().parseArgs(args);
-        ImageComparison imgCmp;
-        if ( arguments.isPresent() ) {
-            imgCmp = create( arguments.get() );
-        } else {
-            imgCmp = createDefault();
-        }
+    public static void main( String[] args ) throws IOException, URISyntaxException {
+        ImageComparison imgCmp = create( args );
         BufferedImage result = imgCmp.compareImages();
         handleResult( imgCmp, ( file ) -> saveImage( file, result ), () -> createGUI( result ) );
+    }
+
+    static ImageComparison create( String... args ) throws IOException, URISyntaxException {
+        Optional<ArgsParser.Arguments> arguments = new ArgsParser().parseArgs(args);
+        return arguments.isPresent() ? create( arguments.get() ) : createDefault();
     }
 
     static ImageComparison createDefault() throws IOException, URISyntaxException {

--- a/src/main/java/ua/comparison/image/ImageComparison.java
+++ b/src/main/java/ua/comparison/image/ImageComparison.java
@@ -39,7 +39,13 @@ public class ImageComparison {
         this( readImageFromResources(image1), readImageFromResources(image2) );
     }
 
-    ImageComparison( BufferedImage image1, BufferedImage image2 ) {
+    /**
+     * Create a new instance of {@link ImageComparison} that can compare the given images.
+     *
+     * @param image1 first image to be compared
+     * @param image2 second image to be compared
+     */
+    public ImageComparison( BufferedImage image1, BufferedImage image2 ) {
         this.image1 = image1;
         this.image2 = image2;
         matrix = populateTheMatrixOfTheDifferences( image1, image2 );
@@ -50,7 +56,9 @@ public class ImageComparison {
         Optional<ArgsParser.Arguments> arguments = parser.parseArgs(args);
         ImageComparison imgCmp;
         if (arguments.isPresent()) {
-            imgCmp = createImageComparison(arguments.get());
+            imgCmp = new ImageComparison(
+                    readImageFromFile(arguments.get().getImage1()),
+                    readImageFromFile(arguments.get().getImage2()));
             Optional<File> destination = arguments.get().getDestinationImage();
             if (destination.isPresent()) {
                 BufferedImage result = imgCmp.compareImages();
@@ -59,21 +67,11 @@ public class ImageComparison {
                 createGUI( imgCmp.compareImages() );
             }
         } else {
-            imgCmp = createDefaultImageComparison();
+            imgCmp = new ImageComparison(
+                    readImageFromResources("image1.png" ),
+                    readImageFromResources("image2.png" ));
             createGUI( imgCmp.compareImages() );
         }
-    }
-
-    private static ImageComparison createImageComparison(ArgsParser.Arguments arguments) throws IOException {
-        return new ImageComparison(
-                readImageFromFile(arguments.getImage1()),
-                readImageFromFile(arguments.getImage2()));
-    }
-
-    private static ImageComparison createDefaultImageComparison() throws IOException, URISyntaxException {
-        return new ImageComparison(
-                readImageFromResources("image1.png"),
-                readImageFromResources("image2.png"));
     }
 
     /**

--- a/src/main/java/ua/comparison/image/ImageComparisonTools.java
+++ b/src/main/java/ua/comparison/image/ImageComparisonTools.java
@@ -129,14 +129,28 @@ public class ImageComparisonTools {
     }
 
     /**
+     * Reads image from the provided file path.
+     * @param path the path where contains image.
+     * @return the {@code BufferedImage} object of this specific image.
+     * @throws IOException
+     */
+    public static BufferedImage readImageFromFile( File path ) throws IOException {
+        return ImageIO.read( path  );
+    }
+
+    /**
      * Save image to the provided path.
      * @param path the path to the saving image.
      * @param image the {@code BufferedImage} object of this specific image.
      * @throws IOException
      */
-    public static void saveImage(String path, BufferedImage image ) throws IOException {
+    public static void saveImage( File path, BufferedImage image ) throws IOException {
+        File dir = path.getParentFile();
         // make dir if it's not using from Gradle.
-        new File( path ).mkdirs();
-        ImageIO.write( image, "png", new File( path ) );
+        boolean dirExists = dir == null || dir.isDirectory() || dir.mkdirs();
+        if (!dirExists) {
+            throw new RuntimeException("Unable to create directory " + dir);
+        }
+        ImageIO.write( image, "png", path );
     }
 }

--- a/src/test/java/ua/comparison/image/ArgsParserUnitTest.java
+++ b/src/test/java/ua/comparison/image/ArgsParserUnitTest.java
@@ -1,0 +1,99 @@
+package ua.comparison.image;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ArgsParserUnitTest {
+
+    private final KnowsIfRan successExitMock = new KnowsIfRan();
+    private final KnowsIfRan errorExitMock = new KnowsIfRan();
+
+    private final ArgsParser parser = new ArgsParser(successExitMock, errorExitMock);
+
+    @Test
+    public void noOptions() {
+        Optional<ArgsParser.Arguments> result = parser.parseArgs();
+        assertFalse(result.isPresent());
+        assertFalse(successExitMock.hasRun);
+        assertFalse(errorExitMock.hasRun);
+    }
+
+    @Test
+    public void shortHelpOption() {
+        Optional<ArgsParser.Arguments> result = parser.parseArgs("-h");
+        assertFalse(result.isPresent());
+        assertTrue(successExitMock.hasRun);
+        assertFalse(errorExitMock.hasRun);
+    }
+
+    @Test
+    public void longHelpOption() {
+        Optional<ArgsParser.Arguments> result = parser.parseArgs("--help");
+        assertFalse(result.isPresent());
+        assertTrue(successExitMock.hasRun);
+        assertFalse(errorExitMock.hasRun);
+    }
+
+    @Test
+    public void compareTwoImagesAndShowInUI() {
+        Optional<ArgsParser.Arguments> result = parser.parseArgs("img1", "img2");
+        assertTrue(result.isPresent());
+
+        ArgsParser.Arguments args = result.get();
+        assertEquals("img1", args.getImage1().getPath());
+        assertEquals("img2", args.getImage2().getPath());
+        assertFalse(args.getDestinationImage().isPresent());
+
+        assertFalse(successExitMock.hasRun);
+        assertFalse(errorExitMock.hasRun);
+    }
+
+    @Test
+    public void compareTwoImagesAndSaveResultInFile() {
+        Optional<ArgsParser.Arguments> result = parser.parseArgs("first", "second", "res");
+        assertTrue(result.isPresent());
+
+        ArgsParser.Arguments args = result.get();
+        assertEquals("first", args.getImage1().getPath());
+        assertEquals("second", args.getImage2().getPath());
+        assertTrue(args.getDestinationImage().isPresent());
+
+        File destinationImage = args.getDestinationImage().get();
+        assertEquals("res", destinationImage.getPath());
+
+        assertFalse(successExitMock.hasRun);
+        assertFalse(errorExitMock.hasRun);
+    }
+
+    @Test
+    public void unrecognizedOption() {
+        Optional<ArgsParser.Arguments> result = parser.parseArgs("wrong");
+        assertFalse(result.isPresent());
+        assertFalse(successExitMock.hasRun);
+        assertTrue(errorExitMock.hasRun);
+    }
+
+    @Test
+    public void tooManyArguments() {
+        Optional<ArgsParser.Arguments> result = parser.parseArgs("a", "b", "c", "d");
+        assertFalse(result.isPresent());
+        assertFalse(successExitMock.hasRun);
+        assertTrue(errorExitMock.hasRun);
+    }
+
+    private static class KnowsIfRan implements Runnable {
+        boolean hasRun = false;
+
+        @Override
+        public void run() {
+            hasRun = true;
+        }
+    }
+
+}

--- a/src/test/java/ua/comparison/image/ImageComparisonToolsUnitTest.java
+++ b/src/test/java/ua/comparison/image/ImageComparisonToolsUnitTest.java
@@ -38,7 +38,7 @@ public class ImageComparisonToolsUnitTest {
     public void testSaveImage() throws IOException, URISyntaxException {
         BufferedImage image = readImageFromResources( "result1.png" );
         String path = "build/test/correct/save/image.png";
-        ImageComparisonTools.saveImage( path, image );
+        ImageComparisonTools.saveImage( new File( path ), image );
         Assert.assertTrue( new File( path ).exists() );
     }
 }

--- a/src/test/java/ua/comparison/image/ImageComparisonUnitTest.java
+++ b/src/test/java/ua/comparison/image/ImageComparisonUnitTest.java
@@ -60,6 +60,17 @@ public class ImageComparisonUnitTest {
     }
 
     @Test
+    public void testCreateWithTwoArgs() throws IOException, URISyntaxException {
+        File image1 = new File( ImageComparison.class.getClassLoader().getResource ( "image1.png" ).toURI().getPath() );
+        File image2 = new File( ImageComparison.class.getClassLoader().getResource ( "image2.png" ).toURI().getPath() );
+        ImageComparison comparison = ImageComparison.create(image1.getAbsolutePath(), image2.getAbsolutePath());
+
+        assertImagesEqual(readImageFromResources("image1.png" ), comparison.getImage1());
+        assertImagesEqual(readImageFromResources("image2.png" ), comparison.getImage2());
+        assertFalse(comparison.getDestination().isPresent());
+    }
+
+    @Test
     public void testCreateWithTwoImagesAsArgs() throws IOException, URISyntaxException {
         File image1 = new File( ImageComparison.class.getClassLoader().getResource ( "image1.png" ).toURI().getPath() );
         File image2 = new File( ImageComparison.class.getClassLoader().getResource ( "image2.png" ).toURI().getPath() );

--- a/src/test/java/ua/comparison/image/ImageComparisonUnitTest.java
+++ b/src/test/java/ua/comparison/image/ImageComparisonUnitTest.java
@@ -3,11 +3,16 @@ package ua.comparison.image;
 import org.junit.Test;
 
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static ua.comparison.image.ImageComparisonTools.*;
 
 
@@ -45,4 +50,82 @@ public class ImageComparisonUnitTest {
     public void testIssue17() throws IOException, URISyntaxException {
         new ImageComparison( "b1#17.png", "b2#17.png" ).compareImages();
     }
+
+    @Test
+    public void testCreateDefault() throws IOException, URISyntaxException {
+        ImageComparison comparison = ImageComparison.createDefault();
+        assertImagesEqual(readImageFromResources("image1.png" ), comparison.getImage1());
+        assertImagesEqual(readImageFromResources("image2.png" ), comparison.getImage2());
+        assertFalse(comparison.getDestination().isPresent());
+    }
+
+    @Test
+    public void testCreateWithTwoImagesAsArgs() throws IOException, URISyntaxException {
+        File image1 = new File( ImageComparison.class.getClassLoader().getResource ( "image1.png" ).toURI().getPath() );
+        File image2 = new File( ImageComparison.class.getClassLoader().getResource ( "image2.png" ).toURI().getPath() );
+        ImageComparison comparison = ImageComparison.create(new ArgsParser.Arguments(image1, image2, null));
+
+        assertImagesEqual(readImageFromResources("image1.png" ), comparison.getImage1());
+        assertImagesEqual(readImageFromResources("image2.png" ), comparison.getImage2());
+        assertFalse(comparison.getDestination().isPresent());
+    }
+
+    @Test
+    public void testCreateWithTwoImagesAndDestinationFileAsArgs() throws IOException, URISyntaxException {
+        File image1 = new File( ImageComparison.class.getClassLoader().getResource ( "image1.png" ).toURI().getPath() );
+        File image2 = new File( ImageComparison.class.getClassLoader().getResource ( "image2.png" ).toURI().getPath() );
+        File destination = Files.createTempFile("image-comparison-test", ".png").toFile();
+        ImageComparison comparison = ImageComparison.create(new ArgsParser.Arguments(image1, image2, destination));
+
+        assertImagesEqual(readImageFromResources("image1.png" ), comparison.getImage1());
+        assertImagesEqual(readImageFromResources("image2.png" ), comparison.getImage2());
+        assertTrue(comparison.getDestination().isPresent());
+        assertEquals(destination, comparison.getDestination().get());
+    }
+
+    @Test
+    public void resultIsHandledCorrectlyWhenItShouldShowUI() throws IOException, URISyntaxException {
+        ImageComparison comparison = new ImageComparison("image1.png", "image2.png");
+        AtomicBoolean savedToFile = new AtomicBoolean(false);
+        AtomicBoolean showUI = new AtomicBoolean(false);
+
+        ImageComparison.handleResult(comparison, file -> savedToFile.set(true), () -> showUI.set(true));
+
+        assertFalse(savedToFile.get());
+        assertTrue(showUI.get());
+    }
+
+    @Test
+    public void resultIsHandledCorrectlyWhenItShouldSaveToFile() throws IOException, URISyntaxException {
+        File image1 = new File( ImageComparison.class.getClassLoader().getResource ( "image1.png" ).toURI().getPath() );
+        File image2 = new File( ImageComparison.class.getClassLoader().getResource ( "image2.png" ).toURI().getPath() );
+        File destination = Files.createTempFile("image-comparison-test", ".png").toFile();
+        ImageComparison comparison = ImageComparison.create(new ArgsParser.Arguments(image1, image2, destination));
+
+        AtomicBoolean savedToFile = new AtomicBoolean(false);
+        AtomicBoolean showUI = new AtomicBoolean(false);
+
+        ImageComparison.handleResult(comparison, file -> savedToFile.set(true), () -> showUI.set(true));
+
+        assertTrue(savedToFile.get());
+        assertFalse(showUI.get());
+    }
+
+    private static void assertImagesEqual(BufferedImage imgA, BufferedImage imgB) {
+        if (imgA.getWidth() != imgB.getWidth() || imgA.getHeight() != imgB.getHeight()) {
+            fail("Images have different dimensions");
+        }
+
+        int width  = imgA.getWidth();
+        int height = imgA.getHeight();
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                if (imgA.getRGB(x, y) != imgB.getRGB(x, y)) {
+                    fail("Images are different, found different pixel at: x = " + x + ", y = " + y);
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
In this PR, I 've added a simple `ArgsParser` class to allow user to pass in options to the program, so that they can compare two images from image files they pass in as arguments.
The user can also give a file where the result should be saved to. Not providing an output file makes the program open the UI, as it does currently.

I also made the jar created by Gradle be runnable (by adding the `Main-Class` entry to the manifest), so now you can run the program with `java -jar image-comparison.jar`.