### PR TITLE
#165: fixed bug with maximalRectangleCount

### DIFF
--- a/src/main/java/com/github/romankh3/image/comparison/ImageComparison.java
+++ b/src/main/java/com/github/romankh3/image/comparison/ImageComparison.java
@@ -351,7 +351,7 @@ public class ImageComparison {
         List<Rectangle> rectanglesForDraw;
         graphics.setColor(Color.RED);
 
-        if (maximalRectangleCount > 0) {
+        if (maximalRectangleCount > 0 && maximalRectangleCount < rectangles.size()) {
             rectanglesForDraw = rectangles.stream()
                     .sorted(Comparator.comparing(Rectangle::size))
                     .skip(rectangles.size() - maximalRectangleCount)

--- a/src/test/java/com/github/romankh3/image/comparison/ImageComparisonUnitTest.java
+++ b/src/test/java/com/github/romankh3/image/comparison/ImageComparisonUnitTest.java
@@ -61,6 +61,21 @@ public class ImageComparisonUnitTest extends BaseTest {
     }
 
     @Test
+    public void testIssue165(){
+        //given
+        ImageComparison imageComparison = new ImageComparison("expected.png", "actual.png");
+        imageComparison.setMaximalRectangleCount(5);
+        BufferedImage expectedImage = readImageFromResources("result.png");
+
+        //when
+        ImageComparisonResult imageComparisonResult = imageComparison.compareImages();
+
+        //then
+        assertEquals(MISMATCH, imageComparisonResult.getImageComparisonState());
+        assertImagesEqual(expectedImage, imageComparisonResult.getResult());
+    }
+
+    @Test
     public void testImagesWithTotallyDifferentImages() {
         //when
         BufferedImage expectedResult = readImageFromResources("totallyDifferentImageResult.png");


### PR DESCRIPTION
# PR Details

When you set some wanted number of rectangles with imageComparison.setMaximalRectangleCount(10); (other then -1) and the comparing found fewer rectangles than this number, you got java.lang.IllegalArgumentException: -3 at
ImageComparison.java:359 because in

       ` rectanglesForDraw = rectangles.stream()

                .sorted(Comparator.comparing(Rectangle::size))

                .skip(rectangles.size()-maximalRectangleCount)

                .collect(Collectors.toList());`
rectangles.size()-maximalRectangleCount will be negative number.

