### PR TITLE
Include rectangles in ImageComparisionResult

### DIFF
--- a/src/main/java/com/github/romankh3/image/comparison/ImageComparison.java
+++ b/src/main/java/com/github/romankh3/image/comparison/ImageComparison.java
@@ -200,7 +200,10 @@ public class ImageComparison {
 
         BufferedImage resultImage = drawRectangles(rectangles);
         saveImageForDestination(resultImage);
-        return ImageComparisonResult.defaultMisMatchResult(expected, actual).setResult(resultImage);
+        return ImageComparisonResult.defaultMisMatchResult(expected, actual)
+                .setResult(resultImage)
+                .setRectangles(rectangles)
+        ;
     }
 
     /**

--- a/src/main/java/com/github/romankh3/image/comparison/model/ImageComparisonResult.java
+++ b/src/main/java/com/github/romankh3/image/comparison/model/ImageComparisonResult.java
@@ -3,6 +3,7 @@ package com.github.romankh3.image.comparison.model;
 import com.github.romankh3.image.comparison.ImageComparisonUtil;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.util.List;
 
 /**
  * Data transfer objects which contains all the needed data for result of the comparison.
@@ -28,10 +29,16 @@ public class ImageComparisonResult {
      * State of the comparison.
      */
     private ImageComparisonState imageComparisonState;
+
     /**
      * The difference percentage between two images.
      */
     private float differencePercent;
+
+    /**
+     * Rectangles of the differences
+     */
+    private List<Rectangle> rectangles;
 
     /**
      * Create default instance of the {@link ImageComparisonResult} with {@link ImageComparisonState#SIZE_MISMATCH}.
@@ -137,5 +144,12 @@ public class ImageComparisonResult {
         return this;
     }
 
+    public List<Rectangle> getRectangles() {
+        return rectangles;
+    }
 
+    public ImageComparisonResult setRectangles(List<Rectangle> rectangles) {
+        this.rectangles = rectangles;
+        return this;
+    }
 }

--- a/src/test/java/com/github/romankh3/image/comparison/model/ImageComparisonResultUnitTest.java
+++ b/src/test/java/com/github/romankh3/image/comparison/model/ImageComparisonResultUnitTest.java
@@ -1,5 +1,9 @@
 package com.github.romankh3.image.comparison.model;
 
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
 import static com.github.romankh3.image.comparison.ImageComparisonUtil.readImageFromResources;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -28,13 +32,15 @@ public class ImageComparisonResultUnitTest {
                 .setImageComparisonState(ImageComparisonState.MATCH)
                 .setExpected(readImageFromResources("expected.png"))
                 .setActual(readImageFromResources("actual.png"))
-                .setResult(readImageFromResources("result.png"));
+                .setResult(readImageFromResources("result.png"))
+                .setRectangles(List.of(Rectangle.createDefault()));
 
         //then
         assertEquals(ImageComparisonState.MATCH, imageComparisonResult.getImageComparisonState());
         assertNotNull(imageComparisonResult.getExpected());
         assertNotNull(imageComparisonResult.getActual());
         assertNotNull(imageComparisonResult.getResult());
+        assertNotNull(imageComparisonResult.getRectangles());
     }
 
 }


### PR DESCRIPTION
# PR Details

## Description

I propose to add to the results of the comparison the coordinates of the rectangles that differ (have been detected).

## Related Issue

https://github.com/romankh3/image-comparison/issues/192

## Motivation and Context

For example: after performing the first comparison, I would like to suggest to the user that the selected fields should be replaced with the excluded ones (he could choose which ones to stay and which not to). Another example is the collection of this data for statistical purposes.

## How Has This Been Tested

Tests included.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
