### PR TITLE
[#205] Set Rectangle Color (Diff / Exclude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ All these configurations can be updated based on your needs.
 | `fillDifferenceRectangles` | Flag which says fill difference rectangles or not. |
 | `percentOpacityDifferenceRectangles` | The desired opacity of the difference rectangle fill. |
 | `allowingPercentOfDifferentPixels` | The percent of the allowing pixels to be different to stay MATCH for comparison. E.g. percent of the pixels, which would ignore in comparison. Value can be from 0.0 to 100.00 |
+| `differenceRectangleColor` | Rectangle color of image difference. By default, it's red. |
+| `excludedRectangleColor` | Rectangle color of excluded part. By default, it's green. |
+
 
 ## Release Notes
 

--- a/src/main/java/com/github/romankh3/image/comparison/ImageComparison.java
+++ b/src/main/java/com/github/romankh3/image/comparison/ImageComparison.java
@@ -139,12 +139,12 @@ public class ImageComparison {
     private double allowingPercentOfDifferentPixels = 0.0;
 
     /**
-     * Sets rectangle color of image difference. Default value is red.
+     * Sets rectangle color of image difference. By default, it's red.
      */
     private Color differenceRectangleColor = Color.RED;
 
     /**
-     * Sets rectangle color of excluded part. Default value is red.
+     * Sets rectangle color of excluded part. By default, it's green.
      */
     private Color excludedRectangleColor = Color.GREEN;
 

--- a/src/main/java/com/github/romankh3/image/comparison/ImageComparison.java
+++ b/src/main/java/com/github/romankh3/image/comparison/ImageComparison.java
@@ -139,6 +139,16 @@ public class ImageComparison {
     private double allowingPercentOfDifferentPixels = 0.0;
 
     /**
+     * Sets rectangle color of image difference. Default value is red.
+     */
+    private Color differenceRectangleColor = Color.RED;
+
+    /**
+     * Sets rectangle color of excluded part. Default value is red.
+     */
+    private Color excludedRectangleColor = Color.GREEN;
+
+    /**
      * Create a new instance of {@link ImageComparison} that can compare the given images.
      *
      * @param expected expected image to be compared
@@ -392,7 +402,7 @@ public class ImageComparison {
      */
     private void drawExcludedRectangles(Graphics2D graphics) {
         if (drawExcludedRectangles) {
-            graphics.setColor(Color.GREEN);
+            graphics.setColor(this.excludedRectangleColor);
             draw(graphics, excludedAreas.getExcluded());
 
             if (fillExcludedRectangles) {
@@ -409,7 +419,7 @@ public class ImageComparison {
      */
     private void drawRectanglesOfDifferences(List<Rectangle> rectangles, Graphics2D graphics) {
         List<Rectangle> rectanglesForDraw;
-        graphics.setColor(Color.RED);
+        graphics.setColor(this.differenceRectangleColor);
 
         if (maximalRectangleCount > 0 && maximalRectangleCount < rectangles.size()) {
             rectanglesForDraw = rectangles.stream()
@@ -675,6 +685,24 @@ public class ImageComparison {
             //todo add warning here
         }
 
+        return this;
+    }
+
+    public Color getDifferenceRectangleColor() {
+        return this.differenceRectangleColor;
+    }
+
+    public ImageComparison setDifferenceRectangleColor(Color differenceRectangleColor) {
+        this.differenceRectangleColor = differenceRectangleColor;
+        return this;
+    }
+
+    public Color getExcludedRectangleColor() {
+        return this.excludedRectangleColor;
+    }
+
+    public ImageComparison setExcludedRectangleColor(Color excludedRectangleColor) {
+        this.excludedRectangleColor = excludedRectangleColor;
         return this;
     }
 }

--- a/src/test/java/com/github/romankh3/image/comparison/ImageComparisonUnitTest.java
+++ b/src/test/java/com/github/romankh3/image/comparison/ImageComparisonUnitTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.romankh3.image.comparison.model.ImageComparisonResult;
 import com.github.romankh3.image.comparison.model.Rectangle;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.ArrayList;
@@ -464,7 +465,9 @@ public class ImageComparisonUnitTest {
                 .setThreshold(400)
                 .setDifferenceRectangleFilling(true, 35.1)
                 .setExcludedRectangleFilling(true, 45.1)
-                .setAllowingPercentOfDifferentPixels(48.15);
+                .setAllowingPercentOfDifferentPixels(48.15)
+                .setDifferenceRectangleColor(Color.RED)
+                .setExcludedRectangleColor(Color.GREEN);
 
         //then
         assertEquals(String.valueOf(100), String.valueOf(imageComparison.getMinimalRectangleSize()));
@@ -478,6 +481,9 @@ public class ImageComparisonUnitTest {
         assertTrue(imageComparison.isFillDifferenceRectangles());
         assertTrue(imageComparison.isFillExcludedRectangles());
         assertEquals(48.15, imageComparison.getAllowingPercentOfDifferentPixels(), 0.0);
+        assertEquals(Color.RED, imageComparison.getDifferenceRectangleColor());
+        assertEquals(Color.GREEN, imageComparison.getExcludedRectangleColor());
+
     }
 
     @DisplayName("Should properly compare in JPEG extension")


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description
As a new feature, I'm suggesting that client can set color for rectangles with the difference.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/romankh3/image-comparison/issues/205

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
About my case,
When we release something, we run image comparison for before and after deployment.
It's job of internal automation app based on Selenium WebDriver.

But we sometime take time to find diff rectangle when it's exists because there are some other parts with red colored.
Maybe you can see it with the following page.
https://www.rakuten.co.jp/

That's why I want to set other color so that we can find difference as soon as possible.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Tested in UT level

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
![Screen Shot 2021-03-25 at 17 48 23](https://user-images.githubusercontent.com/27914419/112445288-4f4b2b00-8d92-11eb-8348-44b0dea68f02.png)