### PR TITLE
#209 - always initialize rectangles

### DIFF
--- a/src/main/java/com/github/romankh3/image/comparison/model/ImageComparisonResult.java
+++ b/src/main/java/com/github/romankh3/image/comparison/model/ImageComparisonResult.java
@@ -4,6 +4,7 @@ import com.github.romankh3.image.comparison.ImageComparisonUtil;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -56,7 +57,8 @@ public class ImageComparisonResult {
                 .setDifferencePercent(differencePercent)
                 .setExpected(expected)
                 .setActual(actual)
-                .setResult(actual);
+                .setResult(actual)
+                .setRectangles(Collections.emptyList());
     }
 
     /**
@@ -88,7 +90,8 @@ public class ImageComparisonResult {
                 .setImageComparisonState(ImageComparisonState.MATCH)
                 .setExpected(expected)
                 .setActual(actual)
-                .setResult(actual);
+                .setResult(actual)
+                .setRectangles(Collections.emptyList());
     }
 
     /**

--- a/src/test/java/com/github/romankh3/image/comparison/ImageComparisonUnitTest.java
+++ b/src/test/java/com/github/romankh3/image/comparison/ImageComparisonUnitTest.java
@@ -449,6 +449,7 @@ public class ImageComparisonUnitTest {
 
         //then
         assertEquals(MATCH, imageComparisonResult.getImageComparisonState());
+        assertEquals(0, imageComparisonResult.getRectangles().size());
     }
 
     @DisplayName("Should properly work getters and setters")
@@ -517,6 +518,7 @@ public class ImageComparisonUnitTest {
 
         //then
         assertEquals(SIZE_MISMATCH, imageComparisonResult.getImageComparisonState());
+        assertEquals(0, imageComparisonResult.getRectangles().size());
         boolean differenceLessThan2 = imageComparisonResult.getDifferencePercent() < 2;
         assertTrue(differenceLessThan2);
     }


### PR DESCRIPTION
# PR Details

`com.github.romankh3.image.comparison.model.ImageComparisonResult.getRectangles()` should not return `null`, so the caller does not need to check for it

## Description

Always initialize the rectangles list..

## Related Issue

#209 

## Motivation and Context

Cleaner code on the caller side

## How Has This Been Tested

Unit-Test

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) - only if the caller ignores the comparison status and checks for a null reference on rectangles

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
