### PR TITLE
Update README.md - fix code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ To save result image, can be used two ways:
         ImageComparisonResult imageComparisonResult = new ImageComparison(expectedImage, actualImage).compareImages();
 
         //Image can be saved after comparison, using ImageComparisonUtil.
-        ImageComparisonUtil.saveImage(resultDestination, resultImage); 
+        ImageComparisonUtil.saveImage(resultDestination, imageComparisonResult.getResult()); 
 ```
 
 ## Demo


### PR DESCRIPTION
Documentation-only change.

`resultImage` was undefined where it was used.