### PR TITLE
getDifferencePercent fix (#233)

### DIFF
--- a/src/main/java/com/github/romankh3/image/comparison/ImageComparisonUtil.java
+++ b/src/main/java/com/github/romankh3/image/comparison/ImageComparisonUtil.java
@@ -142,7 +142,7 @@ public final class ImageComparisonUtil {
         long diff = 0;
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                if(pixelDiff(img1.getRGB(x, y), img2.getRGB(x, y)) > 0)
+                if(img1.getRGB(x, y) != img2.getRGB(x, y))
                     diff++;
             }
         }

--- a/src/main/java/com/github/romankh3/image/comparison/ImageComparisonUtil.java
+++ b/src/main/java/com/github/romankh3/image/comparison/ImageComparisonUtil.java
@@ -142,10 +142,11 @@ public final class ImageComparisonUtil {
         long diff = 0;
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                diff += pixelDiff(img1.getRGB(x, y), img2.getRGB(x, y));
+                if(pixelDiff(img1.getRGB(x, y), img2.getRGB(x, y)) > 0)
+                    diff++;
             }
         }
-        long maxDiff = 3L * 255 * width * height;
+        long maxDiff = (long) width * height;
 
         return (float) (100.0 * diff / maxDiff);
     }

--- a/src/test/java/com/github/romankh3/image/comparison/ImageComparisonUnitTest.java
+++ b/src/test/java/com/github/romankh3/image/comparison/ImageComparisonUnitTest.java
@@ -436,7 +436,7 @@ public class ImageComparisonUnitTest {
 
         //then
         assertEquals(MISMATCH, imageComparisonResult.getImageComparisonState());
-        assertEquals(0.4274517595767975, imageComparisonResult.getDifferencePercent());
+        assertEquals(0.6673570275306702, imageComparisonResult.getDifferencePercent());
         assertImagesEqual(expectedImage, imageComparisonResult.getResult());
     }
 
@@ -519,8 +519,22 @@ public class ImageComparisonUnitTest {
         //then
         assertEquals(SIZE_MISMATCH, imageComparisonResult.getImageComparisonState());
         assertEquals(0, imageComparisonResult.getRectangles().size());
-        boolean differenceLessThan2 = imageComparisonResult.getDifferencePercent() < 2;
-        assertTrue(differenceLessThan2);
+        assertTrue(imageComparisonResult.getDifferencePercent() <= 99.39796);
+    }
+
+    @DisplayName("Should properly get and set percentage of differences #233")
+    @Test
+    public void shouldProperlySetPercentageOfDifferences() {
+        //given
+        ImageComparison imageComparison = new ImageComparison("expected#196.png", "actual#196.png");
+
+        //when
+        float difPercent = imageComparison.compareImages().getDifferencePercent();
+        ImageComparisonResult imageComparisonResult = imageComparison.setAllowingPercentOfDifferentPixels(difPercent)
+                .compareImages();
+
+        //then
+        assertEquals(MATCH, imageComparisonResult.getImageComparisonState());
     }
 
     private void assertImagesEqual(BufferedImage expected, BufferedImage actual) {


### PR DESCRIPTION
# PR Details

Minor fix to getDifferencePercent method in ImageComparisonUtil

## Description

The getDifferencePercent was calculating pixels incorrectly: instead of calculating each different pixels towards the overall counter, it was using an overall sum of differences. This PR fixes that.

## Related Issue

(https://github.com/romankh3/image-comparison/issues/233)

## Motivation and Context

getDifferencePercent can be used to retrieve exact % of differences for ignoring them in ImageComparisonResult config. This can be used to configure exact tests with different images to pass.

## How Has This Been Tested

I have tested these changes in my own project, which uses this library with Selenide for Web visual testing:
https://github.com/nikmazur/ui-visual-testing

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
